### PR TITLE
feat(ragQuery): merge LLM generation into unified RAGQuery activity

### DIFF
--- a/connectors/VectorDB/activity/ragQuery/activity.go
+++ b/connectors/VectorDB/activity/ragQuery/activity.go
@@ -1,9 +1,12 @@
 package ragQuery
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -75,8 +78,24 @@ func New(ctx activity.InitContext) (activity.Activity, error) {
 	if s.TimeoutSeconds <= 0 {
 		s.TimeoutSeconds = 30
 	}
-	ctx.Logger().Infof("RAGQuery initialised: connection=%s provider=%s embeddingModel=%s defaultTopK=%d",
-		conn.GetName(), s.EmbeddingProvider, s.EmbeddingModel, s.DefaultTopK)
+	// LLM generation defaults (only applied when EnableLLMGenerate=true at runtime)
+	if s.LLMProvider == "" {
+		s.LLMProvider = "Ollama"
+	}
+	if s.LLMModel == "" {
+		s.LLMModel = "llama3.1:8b"
+	}
+	if s.LLMBaseURL == "" && s.LLMProvider == "Ollama" {
+		s.LLMBaseURL = "http://localhost:11434"
+	}
+	if s.MaxTokens <= 0 {
+		s.MaxTokens = 1024
+	}
+	if s.SystemPrompt == "" {
+		s.SystemPrompt = "You are a helpful assistant. Answer the question using only the provided context. If the context does not contain enough information, say so."
+	}
+	ctx.Logger().Infof("RAGQuery initialised: connection=%s provider=%s embeddingModel=%s defaultTopK=%d llmGenerate=%v",
+		conn.GetName(), s.EmbeddingProvider, s.EmbeddingModel, s.DefaultTopK, s.EnableLLMGenerate)
 	return &Activity{settings: s, conn: conn}, nil
 }
 
@@ -227,8 +246,25 @@ func (a *Activity) Eval(ctx activity.Context) (bool, error) {
 	// Build sourceDocuments output
 	sourceDocs := searchResultsToInterface(searchResults)
 
+	// Step 4 (optional): LLM answer generation
+	answer := ""
+	if a.settings.EnableLLMGenerate {
+		systemPrompt := a.settings.SystemPrompt
+		if input.SystemPrompt != "" {
+			systemPrompt = input.SystemPrompt
+		}
+		l.Debugf("RAGQuery: generating answer with llmProvider=%s llmModel=%s", a.settings.LLMProvider, a.settings.LLMModel)
+		var llmErr error
+		answer, llmErr = a.generate(opCtx, input.QueryText, formattedContext, systemPrompt)
+		if llmErr != nil {
+			l.Warnf("RAGQuery: LLM generation failed (%v) — returning context only", llmErr)
+			answer = fmt.Sprintf("[LLM generation failed: %s]\n\nRetrieved context:\n%s", llmErr.Error(), formattedContext)
+		}
+	}
+
 	if err := ctx.SetOutputObject(&Output{
 		Success:          true,
+		Answer:           answer,
 		FormattedContext: formattedContext,
 		SourceDocuments:  sourceDocs,
 		QueryEmbedding:   qEmbOut,
@@ -334,4 +370,150 @@ func searchResultsToInterface(results []vectordb.SearchResult) []interface{} {
 		}
 	}
 	return out
+}
+
+// ── LLM generation ──────────────────────────────────────────────────────────
+
+// generate calls the configured LLM to produce an answer grounded in context.
+func (a *Activity) generate(ctx context.Context, query, context_, systemPrompt string) (string, error) {
+	prompt := buildPrompt(systemPrompt, context_, query)
+	switch a.settings.LLMProvider {
+	case "Ollama":
+		return a.generateOllama(ctx, prompt)
+	default: // OpenAI, Azure OpenAI, Custom
+		return a.generateOpenAICompat(ctx, prompt)
+	}
+}
+
+// buildPrompt constructs the full prompt from system prompt, context, and query.
+func buildPrompt(systemPrompt, context_, query string) string {
+	var sb strings.Builder
+	if systemPrompt != "" {
+		sb.WriteString(systemPrompt)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("Context:\n")
+	sb.WriteString(context_)
+	sb.WriteString("\n\nQuestion: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nAnswer:")
+	return sb.String()
+}
+
+// ollamaGenerateRequest is the Ollama /api/generate request body.
+type ollamaGenerateRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+// ollamaGenerateResponse is the non-streaming Ollama response.
+type ollamaGenerateResponse struct {
+	Response string `json:"response"`
+	Error    string `json:"error,omitempty"`
+}
+
+func (a *Activity) generateOllama(ctx context.Context, prompt string) (string, error) {
+	baseURL := strings.TrimRight(a.settings.LLMBaseURL, "/")
+	url := baseURL + "/api/generate"
+
+	reqBody, _ := json.Marshal(ollamaGenerateRequest{
+		Model:  a.settings.LLMModel,
+		Prompt: prompt,
+		Stream: false,
+	})
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("ollama: create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("ollama: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ollama: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result ollamaGenerateResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("ollama: parse response: %w", err)
+	}
+	if result.Error != "" {
+		return "", fmt.Errorf("ollama: %s", result.Error)
+	}
+	return strings.TrimSpace(result.Response), nil
+}
+
+// openAIChatRequest is a minimal OpenAI /v1/chat/completions request body.
+type openAIChatRequest struct {
+	Model       string              `json:"model"`
+	Messages    []openAIChatMessage `json:"messages"`
+	MaxTokens   int                 `json:"max_tokens,omitempty"`
+	Temperature float64             `json:"temperature,omitempty"`
+}
+
+type openAIChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		Message openAIChatMessage `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func (a *Activity) generateOpenAICompat(ctx context.Context, prompt string) (string, error) {
+	baseURL := strings.TrimRight(a.settings.LLMBaseURL, "/")
+	url := baseURL + "/v1/chat/completions"
+
+	reqBody, _ := json.Marshal(openAIChatRequest{
+		Model: a.settings.LLMModel,
+		Messages: []openAIChatMessage{
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens:   a.settings.MaxTokens,
+		Temperature: a.settings.Temperature,
+	})
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("openai-compat: create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if a.settings.LLMAPIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+a.settings.LLMAPIKey)
+	}
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("openai-compat: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("openai-compat: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result openAIChatResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("openai-compat: parse response: %w", err)
+	}
+	if result.Error != nil {
+		return "", fmt.Errorf("openai-compat: %s", result.Error.Message)
+	}
+	if len(result.Choices) == 0 {
+		return "", fmt.Errorf("openai-compat: no choices in response")
+	}
+	return strings.TrimSpace(result.Choices[0].Message.Content), nil
 }

--- a/connectors/VectorDB/activity/ragQuery/activity.js
+++ b/connectors/VectorDB/activity/ragQuery/activity.js
@@ -10,6 +10,12 @@ var core_1 = require("@angular/core"),
     // These fields are hidden when useConnectorEmbedding=true (inherited from connector)
     CONNECTOR_INHERITED_FIELDS = ["embeddingProvider", "embeddingAPIKey", "embeddingBaseURL"],
 
+    // These fields are only visible when enableLLMGenerate=true
+    // Note: systemPrompt is intentionally excluded — both the design-time default (settings)
+    // and the per-request override (input) are always visible so users can prepare/override
+    // the prompt regardless of whether LLM generation is currently enabled.
+    LLM_FIELDS = ["llmProvider", "llmBaseURL", "llmAPIKey", "llmModel", "maxTokens", "temperature"],
+
     RAGQueryActivityHandler = function (t) {
         function e(e, i) {
             var n = t.call(this, e, i) || this;
@@ -18,9 +24,7 @@ var core_1 = require("@angular/core"),
             n.value = function (t, e) { return null };
             n.validate = function (fieldName, ctx) {
                 var useConnector = n.getContextVar(ctx, "useConnectorEmbedding");
-                var useHybrid = n.getContextVar(ctx, "useHybridSearch");
                 var inherit = useConnector === true || useConnector === "true";
-                var hybrid = useHybrid === true || useHybrid === "true";
 
                 // --- Embedding credential fields: hide when connector-level settings are in use ---
                 if (CONNECTOR_INHERITED_FIELDS.indexOf(fieldName) !== -1) {
@@ -29,7 +33,16 @@ var core_1 = require("@angular/core"),
 
                 // --- Hybrid alpha: only relevant when hybrid search is enabled ---
                 if (fieldName === "hybridAlpha") {
+                    var useHybrid = n.getContextVar(ctx, "useHybridSearch");
+                    var hybrid = useHybrid === true || useHybrid === "true";
                     return wi_contrib_1.ValidationResult.newValidationResult().setVisible(hybrid);
+                }
+
+                // --- LLM fields: only visible when enableLLMGenerate=true ---
+                if (LLM_FIELDS.indexOf(fieldName) !== -1) {
+                    var enableLLM = n.getContextVar(ctx, "enableLLMGenerate");
+                    var llmOn = enableLLM === true || enableLLM === "true";
+                    return wi_contrib_1.ValidationResult.newValidationResult().setVisible(llmOn);
                 }
 
                 return null;

--- a/connectors/VectorDB/activity/ragQuery/descriptor.json
+++ b/connectors/VectorDB/activity/ragQuery/descriptor.json
@@ -189,6 +189,100 @@
         "description": "Blend weight for hybrid search: 0.0 = pure BM25 keyword, 1.0 = pure dense vector, 0.5 = balanced (default). Only used when useHybridSearch is true.",
         "appPropertySupport": true
       }
+    },
+    {
+      "name": "enableLLMGenerate",
+      "type": "boolean",
+      "required": false,
+      "value": false,
+      "display": {
+        "name": "Enable LLM Generation",
+        "description": "When enabled, the retrieved context is passed to an LLM to generate an answer. When disabled, only retrieval is performed and the answer output is empty.",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "llmProvider",
+      "type": "string",
+      "required": false,
+      "value": "Ollama",
+      "allowed": [
+        "Ollama",
+        "OpenAI",
+        "Azure OpenAI",
+        "Custom"
+      ],
+      "display": {
+        "name": "LLM Provider",
+        "description": "LLM provider for answer generation. Ollama uses /api/generate; OpenAI/Azure/Custom use /v1/chat/completions. Only used when Enable LLM Generation is true.",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "llmBaseURL",
+      "type": "string",
+      "required": false,
+      "value": "http://localhost:11434",
+      "display": {
+        "name": "LLM Base URL",
+        "description": "Base URL for the LLM API. Ollama default: http://localhost:11434. OpenAI: https://api.openai.com. Only used when Enable LLM Generation is true.",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "llmAPIKey",
+      "type": "string",
+      "required": false,
+      "display": {
+        "name": "LLM API Key",
+        "description": "API key for OpenAI or Azure OpenAI. Leave empty for Ollama. Only used when Enable LLM Generation is true.",
+        "type": "password",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "llmModel",
+      "type": "string",
+      "required": false,
+      "value": "llama3.1:8b",
+      "display": {
+        "name": "LLM Model",
+        "description": "Model name for generation. Ollama: llama3.1:8b. OpenAI: gpt-4o-mini. Only used when Enable LLM Generation is true.",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "systemPrompt",
+      "type": "string",
+      "required": false,
+      "value": "You are a helpful assistant. Answer the question using only the provided context. If the context does not contain enough information, say so.",
+      "display": {
+        "name": "System Prompt",
+        "description": "Default system/instruction prompt prepended before context and query. Can be overridden per-request via the systemPrompt input. Only used when Enable LLM Generation is true.",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "maxTokens",
+      "type": "integer",
+      "required": false,
+      "value": 1024,
+      "display": {
+        "name": "Max Tokens",
+        "description": "Maximum tokens in the generated answer. Only used for OpenAI/Azure/Custom.",
+        "appPropertySupport": true
+      }
+    },
+    {
+      "name": "temperature",
+      "type": "number",
+      "required": false,
+      "value": 0.1,
+      "display": {
+        "name": "Temperature",
+        "description": "Sampling temperature (0.0 = deterministic). Only used for OpenAI/Azure/Custom.",
+        "appPropertySupport": true
+      }
     }
   ],
   "input": [
@@ -209,12 +303,20 @@
       "name": "filters",
       "type": "object",
       "schema": "{\"type\": \"object\", \"description\": \"Key-value filter map. Keys are payload field names. Values can be string, number, boolean, or array (for 'in' match). Example: {\\\"category\\\":\\\"tech\\\",\\\"year\\\":2024,\\\"tags\\\":[\\\"rag\\\",\\\"llm\\\"]}\", \"additionalProperties\": true}"
+    },
+    {
+      "name": "systemPrompt",
+      "type": "string"
     }
   ],
   "output": [
     {
       "name": "success",
       "type": "boolean"
+    },
+    {
+      "name": "answer",
+      "type": "string"
     },
     {
       "name": "formattedContext",

--- a/connectors/VectorDB/activity/ragQuery/metadata.go
+++ b/connectors/VectorDB/activity/ragQuery/metadata.go
@@ -33,6 +33,19 @@ type Settings struct {
 	// HybridAlpha controls the weighting between dense (1.0) and sparse/BM25 (0.0).
 	// Only used when UseHybridSearch=true. Default: 0.5 (balanced fusion).
 	HybridAlpha float64 `md:"hybridAlpha"`
+
+	// EnableLLMGenerate adds an LLM generation step after retrieval.
+	// When false (default), only retrieval is performed and Answer is empty.
+	EnableLLMGenerate bool `md:"enableLLMGenerate"`
+
+	// --- LLM Generation (only used when EnableLLMGenerate=true) ---
+	LLMProvider  string  `md:"llmProvider"`
+	LLMBaseURL   string  `md:"llmBaseURL"`
+	LLMAPIKey    string  `md:"llmAPIKey"`
+	LLMModel     string  `md:"llmModel"`
+	SystemPrompt string  `md:"systemPrompt"`
+	MaxTokens    int     `md:"maxTokens"`
+	Temperature  float64 `md:"temperature"`
 }
 
 // String returns a human-readable representation of Settings with sensitive
@@ -43,10 +56,15 @@ func (s Settings) String() string {
 	if s.EmbeddingAPIKey != "" {
 		apiKey = "[redacted]"
 	}
+	llmKey := ""
+	if s.LLMAPIKey != "" {
+		llmKey = "[redacted]"
+	}
 	return fmt.Sprintf(
-		"ragQuery.Settings{provider:%q model:%q dims:%d topK:%d collection:%q hybrid:%v alpha:%.2f apiKey:%s}",
+		"ragQuery.Settings{provider:%q model:%q dims:%d topK:%d collection:%q hybrid:%v alpha:%.2f llmGenerate:%v llmProvider:%q llmModel:%q apiKey:%s llmApiKey:%s}",
 		s.EmbeddingProvider, s.EmbeddingModel, s.EmbeddingDimensions,
-		s.DefaultTopK, s.DefaultCollection, s.UseHybridSearch, s.HybridAlpha, apiKey,
+		s.DefaultTopK, s.DefaultCollection, s.UseHybridSearch, s.HybridAlpha,
+		s.EnableLLMGenerate, s.LLMProvider, s.LLMModel, apiKey, llmKey,
 	)
 }
 
@@ -56,6 +74,7 @@ type Input struct {
 	CollectionName string                 `md:"collectionName"`
 	TopK           int                    `md:"topK"`
 	Filters        map[string]interface{} `md:"filters"`
+	SystemPrompt   string                 `md:"systemPrompt"`
 }
 
 func (i *Input) ToMap() map[string]interface{} {
@@ -64,6 +83,7 @@ func (i *Input) ToMap() map[string]interface{} {
 		"collectionName": i.CollectionName,
 		"topK":           i.TopK,
 		"filters":        i.Filters,
+		"systemPrompt":   i.SystemPrompt,
 	}
 }
 
@@ -87,12 +107,16 @@ func (i *Input) FromMap(v map[string]interface{}) error {
 			i.Filters = m
 		}
 	}
+	if val, ok := v["systemPrompt"]; ok && val != nil {
+		i.SystemPrompt = fmt.Sprintf("%v", val)
+	}
 	return nil
 }
 
 // Output holds the activity result.
 type Output struct {
 	Success          bool          `md:"success"`
+	Answer           string        `md:"answer"`
 	FormattedContext string        `md:"formattedContext"`
 	SourceDocuments  []interface{} `md:"sourceDocuments"`
 	QueryEmbedding   []interface{} `md:"queryEmbedding"`
@@ -104,6 +128,7 @@ type Output struct {
 func (o *Output) ToMap() map[string]interface{} {
 	return map[string]interface{}{
 		"success":          o.Success,
+		"answer":           o.Answer,
 		"formattedContext": o.FormattedContext,
 		"sourceDocuments":  o.SourceDocuments,
 		"queryEmbedding":   o.QueryEmbedding,


### PR DESCRIPTION
## Summary

Merges the separate `ragQueryGenerate` activity into the main `ragQuery` activity, giving users a single unified activity for both pure retrieval and LLM-assisted generation.

## Changes

### `activity/ragQuery/descriptor.json`
- Added `enableLLMGenerate` boolean toggle (default: `false`)
- Added LLM settings: `llmProvider`, `llmBaseURL`, `llmAPIKey`, `llmModel`, `systemPrompt`, `maxTokens`, `temperature`
- Added `systemPrompt` to inputs (per-request override)
- Added `answer` to outputs

### `activity/ragQuery/metadata.go`
- Extended `Settings` with LLM fields
- Extended `Input` with `SystemPrompt`
- Extended `Output` with `Answer`

### `activity/ragQuery/activity.go`
- Added LLM generation step (Step 4) after retrieval — only runs when `enableLLMGenerate=true`
- Supports Ollama (`/api/generate`) and OpenAI-compatible endpoints (`/v1/chat/completions`)
- LLM failure is non-fatal: returns context with error message rather than aborting

### `activity/ragQuery/activity.js`
- LLM config fields hidden when `enableLLMGenerate=false`
- `systemPrompt` (settings default + input override) always visible
- Follows lazy-eval pattern from `ingestDocuments` for correct WI framework behaviour

## Behaviour

| `enableLLMGenerate` | Result |
|---|---|
| `false` (default) | Pure retrieval — `answer` is empty, `formattedContext` + `sourceDocuments` populated as before |
| `true` | Retrieval + LLM generation — `answer` contains the grounded LLM response |

## Supersedes

The `ragQueryGenerate` activity is superseded by this change.