### PR TITLE
fix(vectordb examples): add Return activity so REST endpoints return a JSON body

### DIFF
--- a/examples/vectordb/azureaisearch-dedicated-test.flogo
+++ b/examples/vectordb/azureaisearch-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-azureaisearch/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-azureaisearch/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "azureaisearch-dedicated-test",
   "description": "Live connector test app for Azure AI Search using dedicated vectordb-azureaisearch connector - CRUD cycle, RAG ingest/query, embeddings, rerank",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -490,13 +514,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -541,6 +602,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -674,13 +742,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -711,6 +813,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -783,13 +892,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -813,6 +954,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -861,13 +1009,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }

--- a/examples/vectordb/elasticsearch-dedicated-test.flogo
+++ b/examples/vectordb/elasticsearch-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-elasticsearch/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-elasticsearch/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "elasticsearch-dedicated-test",
   "description": "Live connector test app for Elasticsearch 8.x using dedicated vectordb-elasticsearch connector - CRUD cycle, RAG ingest/query, embeddings, rerank",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -487,13 +511,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -538,6 +599,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -656,13 +724,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -693,6 +795,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -745,13 +854,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -775,6 +916,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -824,13 +972,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }

--- a/examples/vectordb/lancedb-dedicated-test.flogo
+++ b/examples/vectordb/lancedb-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-lancedb/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-lancedb/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "lancedb-dedicated-test",
   "description": "Live connector test app for LanceDB using dedicated vectordb-lancedb connector - CRUD cycle, RAG ingest/query, embeddings, rerank",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -490,13 +514,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -541,6 +602,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -674,13 +742,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -711,6 +813,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -783,13 +892,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -813,6 +954,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -861,13 +1009,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }

--- a/examples/vectordb/opensearch-dedicated-test.flogo
+++ b/examples/vectordb/opensearch-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-opensearch/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-opensearch/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "opensearch-dedicated-test",
   "description": "Live connector test app for OpenSearch 2.x using dedicated vectordb-opensearch connector - CRUD cycle, RAG ingest/query, embeddings, rerank",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -490,13 +514,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -541,6 +602,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -674,13 +742,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -711,6 +813,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -783,13 +892,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -813,6 +954,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -861,13 +1009,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }

--- a/examples/vectordb/pgvector-dedicated-test.flogo
+++ b/examples/vectordb/pgvector-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-pgvector/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-pgvector/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "pgvector-dedicated-test",
   "description": "Dedicated Pgvector VectorDB connector test suite: all 14 activities across 4 REST endpoints (CRUD, RAG, embed, rerank).",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -490,13 +514,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -541,6 +602,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -674,13 +742,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -711,6 +813,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -783,13 +892,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -813,6 +954,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -861,13 +1009,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }

--- a/examples/vectordb/pinecone-dedicated-test.flogo
+++ b/examples/vectordb/pinecone-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-pinecone/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-pinecone/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "pinecone-dedicated-test",
   "description": "Dedicated Pinecone VectorDB connector test suite: all 14 activities across 4 REST endpoints (CRUD, RAG, embed, rerank).",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -490,13 +514,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -541,6 +602,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -674,13 +742,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -711,6 +813,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -783,13 +892,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -813,6 +954,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -861,13 +1009,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }

--- a/examples/vectordb/redis-dedicated-test.flogo
+++ b/examples/vectordb/redis-dedicated-test.flogo
@@ -17,7 +17,8 @@
     "github.com/tibco/flogo-general/src/app/General/trigger/rest",
     "github.com/project-flogo/contrib/function/coerce",
     "github.com/project-flogo/contrib/function/string",
-    "github.com/mpandav-tibco/flogo-extensions/vectordb-redis/connector"
+    "github.com/mpandav-tibco/flogo-extensions/vectordb-redis/connector",
+    "github.com/project-flogo/contrib/activity/actreturn"
   ],
   "name": "redis-dedicated-test",
   "description": "Dedicated Redis VectorDB connector test suite: all 14 activities across 4 REST endpoints (CRUD, RAG, embed, rerank).",
@@ -58,6 +59,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:crud_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -96,6 +101,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rag_cycle"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -134,6 +143,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:embed_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -172,6 +185,10 @@
             "ref": "github.com/project-flogo/flow",
             "settings": {
               "flowURI": "res://flow:rerank_test"
+            },
+            "output": {
+              "data": "=$.data",
+              "code": "=$.code"
             }
           },
           "reply": {
@@ -283,6 +300,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "ListAfter to LogSummary"
+          },
+          {
+            "id": 12,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -2330,13 +2354,50 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "crud",
+                      "success": true,
+                      "collections_before": "=$activity[ListBefore].totalCount",
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "count_before_delete": "=$activity[CountDocs1].count",
+                      "document_found": "=$activity[GetDoc].found",
+                      "scroll_documents": "=$activity[ScrollDocs].documents",
+                      "count_after_delete": "=$activity[CountDocs2].count",
+                      "collections_after": "=$activity[ListAfter].totalCount"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkxpc3RCZWZvcmUiOnsieCI6MjAwLCJ5Ijo1MH0sIkNyZWF0ZUNvbGxlY3Rpb24iOnsieCI6MzUwLCJ5Ijo1MH0sIkluZ2VzdERvY3MiOnsieCI6NTAwLCJ5Ijo1MH0sIkNvdW50RG9jczEiOnsieCI6NjUwLCJ5Ijo1MH0sIkdldERvYyI6eyJ4Ijo4MDAsInkiOjUwfSwiU2Nyb2xsRG9jcyI6eyJ4Ijo5NTAsInkiOjUwfSwiRGVsZXRlRG9jcyI6eyJ4IjoxMTAwLCJ5Ijo1MH0sIkNvdW50RG9jczIiOnsieCI6MTI1MCwieSI6NTB9LCJEZWxldGVDb2xsZWN0aW9uIjp7IngiOjE0MDAsInkiOjUwfSwiTGlzdEFmdGVyIjp7IngiOjE1NTAsInkiOjUwfSwiTG9nU3VtbWFyeSI6eyJ4IjoxNzAwLCJ5Ijo1MH19",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -2381,6 +2442,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "DeleteRAGCol to LogSummary"
+          },
+          {
+            "id": 6,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -3250,13 +3318,47 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rag",
+                      "success": true,
+                      "ingested": "=$activity[IngestDocs].ingestedCount",
+                      "found": "=$activity[RAGQuery].totalFound",
+                      "answer": "=$activity[RAGQuery].answer",
+                      "sources": "=$activity[RAGQuery].sourceDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkNyZWF0ZVJBR0NvbCI6eyJ4IjoyNTAsInkiOjE1MH0sIkluZ2VzdERvY3MiOnsieCI6NDUwLCJ5IjoyNTB9LCJSQUdRdWVyeSI6eyJ4Ijo2NTAsInkiOjM1MH0sIkRlbGV0ZVJBR0NvbCI6eyJ4Ijo4NTAsInkiOjQ1MH0sIkxvZ1N1bW1hcnkiOnsieCI6MTA1MCwieSI6NTUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -3287,6 +3389,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "EmbedBatch to LogSummary"
+          },
+          {
+            "id": 4,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -3727,13 +3836,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "embed",
+                      "success": true,
+                      "single_dims": "=$activity[EmbedSingle].dimensions",
+                      "batch_dims": "=$activity[EmbedBatch].dimensions"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIkVtYmVkU2luZ2xlIjp7IngiOjI1MCwieSI6MTUwfSwiRW1iZWRCYXRjaCI6eyJ4Ijo0NTAsInkiOjI1MH0sIkxvZ1N1bW1hcnkiOnsieCI6NjUwLCJ5IjozNTB9fQ==",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }
@@ -3757,6 +3898,13 @@
             "to": "LogSummary",
             "type": "label",
             "label": "RerankDocs to LogSummary"
+          },
+          {
+            "id": 3,
+            "from": "LogSummary",
+            "to": "Return",
+            "type": "label",
+            "label": "LogSummary to Return"
           }
         ],
         "tasks": [
@@ -3805,13 +3953,45 @@
                 "logLevel": "INFO"
               }
             }
+          },
+          {
+            "id": "Return",
+            "name": "Return",
+            "description": "",
+            "activity": {
+              "ref": "#actreturn",
+              "settings": {
+                "mappings": {
+                  "code": 200,
+                  "data": {
+                    "mapping": {
+                      "test": "rerank",
+                      "success": "=$activity[RerankDocs].success",
+                      "total": "=$activity[RerankDocs].totalCount",
+                      "ranked": "=$activity[RerankDocs].rankedDocuments"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "fe_metadata": "eyJTdGFydEFjdGl2aXR5Ijp7IngiOjUwLCJ5Ijo1MH0sIlJlcmFua0RvY3MiOnsieCI6MjUwLCJ5IjoxNTB9LCJMb2dTdW1tYXJ5Ijp7IngiOjQ1MCwieSI6MjUwfX0=",
         "metadata": {
           "input": [],
-          "output": [],
-          "fe_metadata": {}
+          "output": [
+            {
+              "name": "code",
+              "type": "float64"
+            },
+            {
+              "name": "data",
+              "type": "object"
+            }
+          ],
+          "fe_metadata": {
+            "output": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"number\"},\"data\":{\"type\":\"object\",\"properties\":{}}}}"
+          }
         },
         "explicitReply": true
       }


### PR DESCRIPTION
## Add Return activity to VectorDB dedicated-test examples

The dedicated-test examples ended each flow with `#log` and relied on the REST trigger's empty auto-reply — so every endpoint returned **HTTP 200 with an empty body**. This adds a proper Return activity across **all 7** dedicated examples (pgvector, redis, pinecone, elasticsearch, opensearch, azureaisearch, lancedb), matching the ActiveSpaces suite pattern.

### Per flow (crud / rag / embed / rerank)
- Import `github.com/project-flogo/contrib/activity/actreturn`
- Append a `Return` (`#actreturn`) task — `code: 200` + `data` mapping of the flow's activity results — linked from the terminal `LogSummary` task
- Declare `metadata.output = [code, data]`
- Handler `action.output = {"data":"=$.data","code":"=$.code"}`

### Verified
`pgvector /api/test/crud` now returns a populated JSON body (was empty 200):
```json
{"test":"crud","success":true,"ingested":5,"count_before_delete":5,
 "count_after_delete":3,"document_found":true,"scroll_documents":[…5 docs…]}
```
All 7 examples build successfully.